### PR TITLE
Fix "symbol multiply defined" error when compiling

### DIFF
--- a/Calc2KeyCE.Calc/src/descriptors.c
+++ b/Calc2KeyCE.Calc/src/descriptors.c
@@ -1,3 +1,4 @@
+#include "descriptors.h"
 #include <usbdrvce.h>
 #include <string.h>
 #include <stdlib.h>
@@ -114,4 +115,8 @@ void init_descriptors() {
 void cleanup_descriptors() {
 	free(string1);
 	free(string2);
+}
+
+usb_standard_descriptors_t* get_descriptors() {
+	return &descriptors;
 }

--- a/Calc2KeyCE.Calc/src/descriptors.h
+++ b/Calc2KeyCE.Calc/src/descriptors.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <usbdrvce.h>
+
+void init_descriptors();
+void cleanup_descriptors();
+usb_standard_descriptors_t* get_descriptors();

--- a/Calc2KeyCE.Calc/src/main.c
+++ b/Calc2KeyCE.Calc/src/main.c
@@ -7,8 +7,7 @@ typedef struct global global_t;
 #include <tice.h>
 #include <stdlib.h>
 #include <string.h>
-#include <usbdrvce.h>
-#include "descriptors.c"
+#include "descriptors.h"
 #include <keypadc.h>
 #include <stdio.h>
 
@@ -52,7 +51,7 @@ int main(void)
 
 	init_descriptors();
 
-	if ((error = usb_Init(handleUsbEvent, &global, &descriptors, USB_DEFAULT_INIT_FLAGS)) == USB_SUCCESS)
+	if ((error = usb_Init(handleUsbEvent, &global, get_descriptors(), USB_DEFAULT_INIT_FLAGS)) == USB_SUCCESS)
 	{
 		while ((error = usb_WaitForInterrupt()) == USB_SUCCESS)
 		{


### PR DESCRIPTION
This fixes the following error during compile due to including a `*.c` file in another `*.c` file, which is not best practice.
![image](https://github.com/dnmalenke/Calc2KeyCE/assets/1176979/34ac559d-51af-4ba6-bd43-be023eea61eb)
